### PR TITLE
fixed Minimum value must be a float. bug

### DIFF
--- a/SphinxBehavior.php
+++ b/SphinxBehavior.php
@@ -93,7 +93,7 @@ class SphinxBehavior extends ModelBehavior {
                     $method = 'Set' . $key;
                     foreach ($setting as $arg) {
                         $arg[3] = empty($arg[3]) ? false : $arg[3];
-                        $this->runtime[$model->alias]['sphinx']->{$method}($arg[0], (array)$arg[1], $arg[2], $arg[3]);
+                        $this->runtime[$model->alias]['sphinx']->{$method}($arg[0], $arg[1], $arg[2], $arg[3]);
                     }
                    break;
                 case 'matchMode':


### PR DESCRIPTION
If I use the filterFloatRange method, I get this bug and I believe the reason is that the second paramter is transformed to an array.

In contrast to the setFilter-method (called in line 88) $arg[1] is not an array, but it is a float (as the method name filterFloatRange suggests).